### PR TITLE
add to Presentation fields, view, tile

### DIFF
--- a/ploneconf2016/policy/browser/templates/presentation.pt
+++ b/ploneconf2016/policy/browser/templates/presentation.pt
@@ -28,8 +28,10 @@
         </h4>
 
 	<h4>
-	  <span>From</span> <span tal:replace="structure view/w/IEventBasic.start/render" /> 
-	  <span>to</span> <span tal:replace="structure view/w/IEventBasic.end/render" />
+	  <a href="" tal:omit-tag="not: here/schedule_url" tal:attributes="href here/schedule_url">
+	    <span>From</span> <span tal:replace="structure view/w/IEventBasic.start/render" /> 
+	    <span>to</span> <span tal:replace="structure view/w/IEventBasic.end/render" />
+	  </a>
 	</h4>
 	<h4>
 	  <span>Location:</span> <span tal:replace="structure view/w/IEventLocation.location/render" />
@@ -38,13 +40,13 @@
         <div tal:condition="context/body" tal:content="structure context/body/output" ></div>
 
         <h4 tal:condition="context/slides_url"><b>
-            <a href="" tal:attributes="href here/slides" target="_blank">See the presentation slides</a>
+            <a href="" tal:attributes="href here/slides_url" target="_blank">See the presentation slides</a>
         </h4> 
         <div tal:condition="context/slides_embed" tal:replace="structure context/slides_embed">
         </div> 
 
         <h4 tal:condition="context/video_url"><b>
-            <a href="" tal:attributes="href here/video" target="_blank">See the presentation video</a>
+            <a href="" tal:attributes="href here/video_url" target="_blank">See the presentation video</a>
         </h4>
         <div tal:condition="context/video_embed" tal:replace="structure context/video_embed">
         </div> 

--- a/ploneconf2016/policy/browser/templates/presentation.pt
+++ b/ploneconf2016/policy/browser/templates/presentation.pt
@@ -37,12 +37,17 @@
 
         <div tal:condition="context/body" tal:content="structure context/body/output" ></div>
 
-        <h4 tal:condition="context/slides"><b>
+        <h4 tal:condition="context/slides_url"><b>
             <a href="" tal:attributes="href here/slides" target="_blank">See the presentation slides</a>
         </h4> 
-        <h4 tal:condition="context/video"><b>
+        <div tal:condition="context/slides_embed" tal:replace="structure context/slides_embed">
+        </div> 
+
+        <h4 tal:condition="context/video_url"><b>
             <a href="" tal:attributes="href here/video" target="_blank">See the presentation video</a>
         </h4>
+        <div tal:condition="context/video_embed" tal:replace="structure context/video_embed">
+        </div> 
 
     </metal:block>
 

--- a/ploneconf2016/policy/browser/templates/presentation.pt
+++ b/ploneconf2016/policy/browser/templates/presentation.pt
@@ -26,7 +26,17 @@
                 <span>${audience}</span><span tal:condition="not:repeat/audience/end">,</span>
             </span>
         </h4>
+
+	<h4>
+	  <span>From</span> <span tal:replace="structure view/w/IEventBasic.start/render" /> 
+	  <span>to</span> <span tal:replace="structure view/w/IEventBasic.end/render" />
+	</h4>
+	<h4>
+	  <span>Location:</span> <span tal:replace="structure view/w/IEventLocation.location/render" />
+	</h4>
+
         <div tal:condition="context/body" tal:content="structure context/body/output" ></div>
+
         <h4 tal:condition="context/slides"><b>
             <a href="" tal:attributes="href here/slides" target="_blank">See the presentation slides</a>
         </h4> 

--- a/ploneconf2016/policy/browser/templates/presentation.pt
+++ b/ploneconf2016/policy/browser/templates/presentation.pt
@@ -27,6 +27,12 @@
             </span>
         </h4>
         <div tal:condition="context/body" tal:content="structure context/body/output" ></div>
+        <h4 tal:condition="context/slides"><b>
+            <a href="" tal:attributes="href here/slides" target="_blank">See the presentation slides</a>
+        </h4> 
+        <h4 tal:condition="context/video"><b>
+            <a href="" tal:attributes="href here/video" target="_blank">See the presentation video</a>
+        </h4>
 
     </metal:block>
 

--- a/ploneconf2016/policy/content/models/presentation.xml
+++ b/ploneconf2016/policy/content/models/presentation.xml
@@ -49,16 +49,28 @@
           <source>ploneconf2016.policy.content.vocabularies.AUDIENCE_TYPES</source>
       </value_type>
     </field>
-    <field name="slides" type="zope.schema.TextLine"
+    <field name="slides_url" type="zope.schema.TextLine"
            indexer:searchable="true">
       <description>URL of slides</description>
       <title>Slides</title>
       <required>False</required>
     </field>
-    <field name="video" type="zope.schema.TextLine"
+    <field name="slides_embed" type="zope.schema.Text"
+           indexer:searchable="false">
+      <description>Embed code for slides</description>
+      <title>Slides embed code</title>
+      <required>False</required>
+    </field>
+    <field name="video_url" type="zope.schema.TextLine"
            indexer:searchable="true">
       <description>URL of video recording</description>
       <title>Video</title>
+      <required>False</required>
+    </field>
+    <field name="video_embed" type="zope.schema.Text"
+           indexer:searchable="false">
+      <description>Embed code for video recording</description>
+      <title>Video embed code</title>
       <required>False</required>
     </field>
   </schema>

--- a/ploneconf2016/policy/content/models/presentation.xml
+++ b/ploneconf2016/policy/content/models/presentation.xml
@@ -49,5 +49,17 @@
           <source>ploneconf2016.policy.content.vocabularies.AUDIENCE_TYPES</source>
       </value_type>
     </field>
+    <field name="slides" type="zope.schema.TextLine"
+           indexer:searchable="true">
+      <description>URL of slides</description>
+      <title>Slides</title>
+      <required>False</required>
+    </field>
+    <field name="video" type="zope.schema.TextLine"
+           indexer:searchable="true">
+      <description>URL of video recording</description>
+      <title>Video</title>
+      <required>False</required>
+    </field>
   </schema>
 </model>

--- a/ploneconf2016/policy/content/models/presentation.xml
+++ b/ploneconf2016/policy/content/models/presentation.xml
@@ -49,26 +49,22 @@
           <source>ploneconf2016.policy.content.vocabularies.AUDIENCE_TYPES</source>
       </value_type>
     </field>
-    <field name="slides_url" type="zope.schema.TextLine"
-           indexer:searchable="true">
+    <field name="slides_url" type="zope.schema.TextLine">
       <description>URL of slides</description>
       <title>Slides</title>
       <required>False</required>
     </field>
-    <field name="slides_embed" type="zope.schema.Text"
-           indexer:searchable="false">
+    <field name="slides_embed" type="zope.schema.Text">
       <description>Embed code for slides</description>
       <title>Slides embed code</title>
       <required>False</required>
     </field>
-    <field name="video_url" type="zope.schema.TextLine"
-           indexer:searchable="true">
+    <field name="video_url" type="zope.schema.TextLine">
       <description>URL of video recording</description>
       <title>Video</title>
       <required>False</required>
     </field>
-    <field name="video_embed" type="zope.schema.Text"
-           indexer:searchable="false">
+    <field name="video_embed" type="zope.schema.Text">
       <description>Embed code for video recording</description>
       <title>Video embed code</title>
       <required>False</required>

--- a/ploneconf2016/policy/content/models/presentation.xml
+++ b/ploneconf2016/policy/content/models/presentation.xml
@@ -69,5 +69,10 @@
       <title>Video embed code</title>
       <required>False</required>
     </field>
+    <field name="schedule_url" type="zope.schema.TextLine">
+      <description>URL of this presentation on the schedule</description>
+      <title>Schedule</title>
+      <required>False</required>
+    </field>
   </schema>
 </model>

--- a/ploneconf2016/policy/content/presentation.py
+++ b/ploneconf2016/policy/content/presentation.py
@@ -1,7 +1,7 @@
 from plone import api
 from plone.indexer.decorator import indexer
 from plone.supermodel import model
-from Products.Five import BrowserView
+from plone.dexterity.browser.view import DefaultView
 from .vocabularies import PRESENTATION_DURATION_TYPES, LEVEL_TYPES, \
 AUDIENCE_TYPES
 
@@ -9,7 +9,7 @@ class IPresentation(model.Schema):
     model.load('models/presentation.xml')
 
 
-class PresentationView(BrowserView):
+class PresentationView(DefaultView):
 
     def duration_vocab(self):
         return PRESENTATION_DURATION_TYPES

--- a/ploneconf2016/policy/profiles/default/types/presentation.xml
+++ b/ploneconf2016/policy/profiles/default/types/presentation.xml
@@ -27,6 +27,7 @@
   <element value="plone.app.relationfield.behavior.IRelatedItems"/>
   <element value="collective.relatedslider.behavior.IRelatedSlider"/>
   <element value="plone.app.contenttypes.behaviors.collection.ICollection"/>
+  <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
  </property>
  <property name="schema">ploneconf2016.policy.content.presentation.IPresentation</property>
  <alias from="(Default)" to="(dynamic view)"/>

--- a/ploneconf2016/policy/tiles/templates/presentation.pt
+++ b/ploneconf2016/policy/tiles/templates/presentation.pt
@@ -1,6 +1,6 @@
 <div class="PresentationTile presentation-${python:content.duration and content.duration.lower()}" tal:define="content nocall:view/content_context|nothing"
      tal:condition="nocall:content">
-    <a class="TileLink" title="${content/Title}" href="${content/absolute_url}"></a>
+    <a id="${content/id}" class="TileLink" title="${content/Title}" href="${content/absolute_url}"></a>
     <h3 class="TileTitle">${content/title}</h3>
     <p class="TileAuthor" tal:condition="view/speaker|nothing">${view/speaker}</p>
     <p class="TileDescription">${content/description|nothing}</p>


### PR DESCRIPTION
Add fields for slides & video URLs and embed codes. Add field for schedule URL so we can point to where the Presentation is on the schedule page. Add id attribute to <a> tag on the tile so we can point right to here instead of to the general page. Display start and end dates and times and the location of the talk.